### PR TITLE
Optional leap year fix for Issue 5

### DIFF
--- a/usp_LoyaltyCohort_v6.sql
+++ b/usp_LoyaltyCohort_v6.sql
@@ -138,7 +138,7 @@ if object_id('tempdb..#DX_baseline_FULL') is not null drop table #DX_baseline_FU
 	Into #DX_baseline_FULL
 	From observation_fact o, n 
 	Where o.CONCEPT_CD = n.CONCEPT_CD
-		AND o.START_DATE >=  dateadd(dd,-365, @indexDate)
+		AND o.START_DATE >=  dateadd(yy,-1,@indexDate)
 		AND o.START_DATE < @indexDate	
 	group by patient_num
 	
@@ -173,7 +173,7 @@ if object_id('tempdb..#DX_baseline_FULL') is not null drop table #DX_baseline_FU
 	into #DX_baseline
 	from observation_fact o, #DX_params p
 	where o.Concept_cd = p.CONCEPT_CD
-		AND o.START_DATE >=  dateadd(dd,-365, @indexDate)
+		AND o.START_DATE >=  dateadd(yy,-1,@indexDate)
 		AND o.START_DATE < @indexDate
    
 Set @MessageCnt = @MessageCnt + 1 
@@ -204,7 +204,7 @@ RAISERROR(@MessageText,0,1) WITH NOWAIT;
 	into #PX_baseline
 	from observation_fact o, #PX_params p
 	where o.CONCEPT_CD = p.CONCEPT_CD
-		AND o.START_DATE >=  dateadd(dd,-365, @indexDate)
+		AND o.START_DATE >=  dateadd(yy,-1,@indexDate)
 		AND o.START_DATE < @indexDate
 
 	CREATE CLUSTERED INDEX ndx_PX_bl ON #PX_baseline (patient_num, concept_cd, provider_id );
@@ -235,7 +235,7 @@ RAISERROR(@MessageText,0,1) WITH NOWAIT;
 	into #lab_baseline
 	from observation_fact o, #Lab_params p
 	where o.CONCEPT_CD = p.CONCEPT_CD
-		AND o.START_DATE >=  dateadd(dd,-365, @indexDate)
+		AND o.START_DATE >=  dateadd(yy,-1,@indexDate)
 		AND o.START_DATE < @indexDate
 
 
@@ -268,7 +268,7 @@ RAISERROR(@MessageText,0,1) WITH NOWAIT;
 							Select o.patient_num, count(distinct(convert(date,o.start_date))) as Counts 
 							From observation_fact o, MedCodes M
 							Where o.CONCEPT_CD = M.C_BASECODE
-									AND o.START_DATE >=  dateadd(dd,-365, @indexDate)
+									AND o.START_DATE >=  dateadd(yy,-1,@indexDate)
 									AND o.START_DATE < @indexDate
 							group by patient_num
 							)  X
@@ -284,7 +284,7 @@ RAISERROR(@MessageText,0,1) WITH NOWAIT;
 	select patient_num , count(distinct convert(date, start_date)) as cnt  --count(distinct encounter_num) as cnt 
 	into #visit_outpatient
 	from visit_dimension 
-	where (START_DATE >=  dateadd(dd,-365, @indexDate)
+	where (START_DATE >=  dateadd(yy,-1,@indexDate)
 			AND START_DATE < @indexDate
 			)
 	AND 	[INOUT_CD] in (select distinct c_basecode
@@ -304,7 +304,7 @@ RAISERROR(@MessageText,0,1) WITH NOWAIT;
 	select patient_num , count(distinct convert(date, start_date)) as cnt  --count(distinct encounter_num) as cnt 
 	into #visit_ED
 	from visit_dimension 
-	where (	START_DATE >=  dateadd(dd,-365, @indexDate)
+	where (	START_DATE >=  dateadd(yy,-1,@indexDate)
 			AND START_DATE < @indexDate
 			)
 	AND 	[INOUT_CD] in (select distinct c_basecode
@@ -324,7 +324,7 @@ RAISERROR(@MessageText,0,1) WITH NOWAIT;
 	select patient_num , count(distinct encounter_num) as cnt --count(distinct convert(date, start_date)) as cnt
 	into #visit_inpatient
 	from visit_dimension 
-	where ( START_DATE >=  dateadd(dd,-365, @indexDate)
+	where ( START_DATE >=  dateadd(yy,-1,@indexDate)
 			AND START_DATE < @indexDate
 			)
 	AND 	[INOUT_CD] in (select distinct c_basecode
@@ -369,7 +369,7 @@ RAISERROR(@MessageText,0,1) WITH NOWAIT;
 	--							From #px_params -- jgk isn't this only pts with a procedure code?
 	--							Where feature_name =  'MD visit') X					
 	--where O.CONCEPT_CD = X.CONCEPT_CD
-	--		AND (convert(date, START_DATE) >=  dateadd(dd,-365,convert(date,@indexDate))
+	--		AND (convert(date, START_DATE) >=  dateadd(yy,-1,convert(date,@indexDate))
 	--		AND convert(date, START_DATE) <= dateadd(dd,-1,convert(date,@indexDate))
 	--		)
 	--		AND (O.PROVIDER_ID is not null and O.provider_id <> '' and O.provider_id <> '@')


### PR DESCRIPTION
Alter the stored procedure to use dateadd(yy,-1,@indexDate) instead of dateadd(dd,-365,@indexDate) for its census period start date. This was extracting encounters/facts from Feb 2, 2020 forward due to 2020 being a leap year.