### PR TITLE
Extend index date filter

### DIFF
--- a/ExtractFullReport.sql
+++ b/ExtractFullReport.sql
@@ -11,24 +11,24 @@ FROM [I2B2ACT].[4CEX2].[FourCE_LocalPatientSummary] /* SOURCE OF YOUR COHORT TO 
 
 /* Alter @site parameter to your site */
 /* If your site stores demographic facts set @demographics_facts=1, if there are no demographic facts in observation_fact set @demographic_facts=0 */
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=1,  @demographic_facts=1, @gendered=0, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=1,  @demographic_facts=1, @gendered=1, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=2,  @demographic_facts=1, @gendered=0, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=2,  @demographic_facts=1, @gendered=1, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=5,  @demographic_facts=1, @gendered=0, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=5,  @demographic_facts=1, @gendered=1, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=10, @demographic_facts=1, @gendered=0, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=10, @demographic_facts=1, @gendered=1, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=1,  @gendered=0, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=1,  @gendered=1, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=2,  @gendered=0, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=2,  @gendered=1, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=5,  @gendered=0, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=5,  @gendered=1, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=10, @gendered=0, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=10, @gendered=1, @filter_by_existing_cohort=0, @cohort_filter=@cfilter, @output=0
 
 /* Filtered by existing cohort */
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=1,  @demographic_facts=1, @gendered=0, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=1,  @demographic_facts=1, @gendered=1, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=2,  @demographic_facts=1, @gendered=0, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=2,  @demographic_facts=1, @gendered=1, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=5,  @demographic_facts=1, @gendered=0, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=5,  @demographic_facts=1, @gendered=1, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=10, @demographic_facts=1, @gendered=0, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
-EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20210201', @site='UKY', @lookbackYears=10, @demographic_facts=1, @gendered=1, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=1,  @gendered=0, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=1,  @gendered=1, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=2,  @gendered=0, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=2,  @gendered=1, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=5,  @gendered=0, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=5,  @gendered=1, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=10, @gendered=0, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
+EXEC [dbo].[usp_LoyaltyCohort_opt] @indexDate = '20220101', @site='UKY', @lookbackYears=10, @gendered=1, @filter_by_existing_cohort=1, @cohort_filter=@cfilter, @output=0
 
 
 SELECT DISTINCT LDS.FILTER_BY_COHORT_YN, LDS.COHORT_NAME, LDS.[SITE], LDS.[EXTRACT_DTTM], LDS.[LOOKBACK_YR], LDS.GENDER_DENOMINATORS_YN, LDS.[CUTOFF_FILTER_YN], LDS.[Summary_Description], LDS.[tablename], LDS.[Num_DX1], LDS.[Num_DX2], LDS.[MedUse1], LDS.[MedUse2]
@@ -49,3 +49,4 @@ SELECT DISTINCT LDS.FILTER_BY_COHORT_YN, LDS.COHORT_NAME, LDS.[SITE], LDS.[EXTRA
 FROM [dbo].[loyalty_dev_summary] LDS
 WHERE LDS.Summary_Description = 'PercentOfSubjects' 
 ORDER BY LDS.FILTER_BY_COHORT_YN, LDS.COHORT_NAME, LDS.LOOKBACK_YR, LDS.GENDER_DENOMINATORS_YN, LDS.CUTOFF_FILTER_YN, LDS.TABLENAME;
+


### PR DESCRIPTION
This branch adds the ability to anchor the Loyalty score to an index_dt for each patient, instead of the static index_dt. This required a major overhaul to allow for conditional operations to be performed throughout. If after testing, we feel that this should ALWAYS be the functionality, we could always refactor the conditionals back out and only filter on the date in the cohort_filter.